### PR TITLE
feat: install Babel plugin for IE11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
     "@babel/plugin-transform-runtime": "^7.1.0",
+    "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/register": "^7.0.0",
     "@commitlint/cli": "^7.2.1",
@@ -135,6 +136,7 @@
           [
             "@babel/plugin-transform-runtime"
           ],
+          "@babel/plugin-transform-template-literals",
           "add-module-exports"
         ]
       }


### PR DESCRIPTION
After upgrading to version `0.2.2`, I noticed that the NPM package's `lib/index.js` file still contained an ES6 template literal:

```
var getIndent = function getIndent(level) {
  return `${eol}${indentString.repeat(level)}`;
};
```

This pull request adds `@babel/plugin-transform-template-literals` to the build process, which transpiles the template literals into something that IE11 will be able to understand:

```
var getIndent = function getIndent(level) {
  return "".concat(eol).concat(indentString.repeat(level));
};
```

See https://github.com/Scrum/posthtml-beautify/issues/224