### PR TITLE
feat: revert previous change and add src files to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
     "@babel/plugin-transform-runtime": "^7.1.0",
-    "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/register": "^7.0.0",
     "@commitlint/cli": "^7.2.1",
@@ -136,7 +135,6 @@
           [
             "@babel/plugin-transform-runtime"
           ],
-          "@babel/plugin-transform-template-literals",
           "add-module-exports"
         ]
       }


### PR DESCRIPTION
## Overview

This pull request reverts [my previous changes](https://github.com/Scrum/posthtml-beautify/pull/226) and adds the `/src` directory to the NPM package.

## Explanation

I'm currently working on a Nuxt application. Since it's a universal/isomorphic app, Webpack generates both server-side and client-side bundles, so all of my application code must be capable of running in both Node and in the browser.

Unfortunately, [my previous pull request](https://github.com/Scrum/posthtml-beautify/pull/226) fixed some but not all of the JavaScript errors that I was experiencing in IE11. After some additional experimentation, I was able to fix all of the remaining issues by changing the Babel build target from Node:
```
"@babel/preset-env", {
  "targets": {
    "node": "4"
  }
}
```
to a list of browsers (with [useBuiltIns](https://babeljs.io/docs/en/babel-preset-env#usebuiltins) defined, to ensure that the required polyfills are included):
```
"@babel/preset-env", {
  "targets": {
    "browsers": [
      "ie 11",
      "last 2 versions"
    ]
  },
  "useBuiltIns": "usage"
}
```
However, I didn't create a pull request because I was concerned that changing the build target from Node to [browserlist](https://github.com/browserslist/browserslist) could potentially affect other developers who rely on the `posthtml-beautify` package, and I'm no expert on NPM publishing best practices, so I wasn't 100% confident in what I had done.

I'm also uncertain whether package authors should be expected to transpile their distributed code for older browsers, or whether the apps that consume the packages should be responsible for doing so on their end. After doing some research and discussing this with my colleagues and some of the core Nuxt team members on Discord, there seem to be differing opinions in the JavaScript community regarding this issue.

Some NPM package developers distribute [separate builds](https://docs.npmjs.com/files/package.json#main): one for Node and another for browsers:

package.json
```
{
  "main": "dist/the-package.server.js",
  "browser": "dist/the-package.client.js"
}
```

But which version would I import into a universal/isomorphic app? I'm not sure.

Then there's the question of which module formats to publish (UMD, CommonJS, ESM, etc.). This gets pretty complicated too.

I don't claim to know the answers to these questions, but I do know that I'm having trouble importing `posthtml-beautify/lib/index.js` into my Nuxt application and transpiling it for IE11. Some people in the Nuxt Discord chat rooms were of the opinion that NPM package authors should distribute the source code alongside their bundled code (i.e. publish both the `/src` as well as the `/lib` or `/dist` directories). That way, apps that consume the package can import the source files directly and bundle/transpile them however they like.

Using this fork, I've been able to transpile the package via Webkack in my `nuxt.config.js`, like this:
```
export default {
  mode: "universal",
  build: {
    transpile: "posthtml-beautify/src"
```

Then import it into my Nuxt components like this:
```
import beautify from "posthtml-beautify/src";
```

This method is working for me and it seems like the simplest solution, but I'd love to know what everyone else thinks!